### PR TITLE
Add option to sort table keys when stringifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ json.parse(str)
 
 ## API
 
-* json.stringify(obj, replacer, space, print_address)
+* json.stringify(obj, replacer, space, print_address, sort_table_keys)
   * ``obj`` ``<any>`` 需要序列化的值
   * ``replacer`` ``<function>`` 同 [js JSON.stringify](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
   * ``space`` ``<number>`` 空格数
   * ``print_address`` ``<boolean>`` 输出内存地址
+  * ``sort_table_keys`` ``<boolean>``
 * json.parse(str, without_null)
   * ``str`` ``<string>`` 需要反序列化的值
   * ``without_null`` ``<boolean>`` 是否输出 null 值，默认使用 ``json.null``

--- a/lib/pretty/json.lua
+++ b/lib/pretty/json.lua
@@ -9,11 +9,12 @@ local json = {
     null = Constant.NULL
 }
 
-function json.stringify(obj, replacer, space, print_address)
+function json.stringify(obj, replacer, space, print_address, sort_table_keys)
     if type(space) ~= "number" then space = 0 end
 
     return Serializer({
         print_address = print_address,
+        sort_table_keys = sort_table_keys,
         stream = {
             fragments = {},
             write = function(self, ...)

--- a/lib/pretty/json/serializer.lua
+++ b/lib/pretty/json/serializer.lua
@@ -29,8 +29,26 @@ local function escape_str(s)
     return s
 end
 
+local function sorted_pairs(obj)
+    local sorted_keys = {}
+    for key in pairs(obj) do
+        table.insert(sorted_keys, key)
+    end
+
+    table.sort(sorted_keys)
+
+    local i = 0
+    return function()
+        if i < #sorted_keys then
+            i = i + 1
+            return sorted_keys[i], obj[sorted_keys[i]]
+        end
+    end
+end
+
 local Serializer = {
     print_address = false,
+    sort_table_keys = false,
     max_depth = 100000
 }
 
@@ -40,6 +58,7 @@ setmetatable(Serializer, {
             depth = 0,
             max_depth = opts.max_depth,
             print_address = opts.print_address,
+            sort_table_keys = opts.sort_table_keys,
             stream = opts.stream
         }
 
@@ -102,10 +121,11 @@ end
 
 function Serializer:table(obj, replacer, indent, space)
     local stream = self.stream
+    local iter = self.sort_table_keys and sorted_pairs or pairs
 
     stream:write("{")
     local len = 0
-    for k, v in pairs(obj) do
+    for k, v in iter(obj) do
         if replacer then v = replacer(k, v) end
 
         if v ~= nil then

--- a/lib/pretty/json/serializer.lua
+++ b/lib/pretty/json/serializer.lua
@@ -31,19 +31,18 @@ end
 
 local function sorted_pairs(obj)
     local sorted_keys = {}
+
     for key in pairs(obj) do
         table.insert(sorted_keys, key)
     end
 
     table.sort(sorted_keys)
 
-    local i = 0
-    return function()
-        if i < #sorted_keys then
-            i = i + 1
-            return sorted_keys[i], obj[sorted_keys[i]]
+    return coroutine.wrap(function()
+        for _, key in ipairs(sorted_keys) do
+            coroutine.yield(key, obj[key])
         end
-    end
+    end)
 end
 
 local Serializer = {


### PR DESCRIPTION
On messi cooktop we love the new `erd_lock_update` command because we've been changing the lock a ton. However each time we do it adds >10K lines of noise to the diff because the table keys are emitted into the json in no particular order.

Ex: https://github.com/geappliances/cooking.messi-cooktop/pull/662

This change adds a `sort_table_keys` option to the lib so the output is consistent between runs

- [x] test in messi-cooktop