### PR TITLE
Add empty_table_as_array

### DIFF
--- a/lib/pretty/json.lua
+++ b/lib/pretty/json.lua
@@ -9,13 +9,14 @@ local json = {
     null = Constant.NULL
 }
 
-function json.stringify(obj, replacer, space, print_address, sort_table_keys, escape_string_values)
+function json.stringify(obj, replacer, space, print_address, sort_table_keys, escape_string_values, empty_table_as_array)
     if type(space) ~= "number" then space = 0 end
 
     return Serializer({
         print_address = print_address,
         sort_table_keys = sort_table_keys,
         escape_string_values = escape_string_values,
+        empty_table_as_array = empty_table_as_array,
         stream = {
             fragments = {},
             write = function(self, ...)

--- a/lib/pretty/json/serializer.lua
+++ b/lib/pretty/json/serializer.lua
@@ -5,7 +5,7 @@ local Constant = require "pretty.json.constant"
 local NULL = Constant.NULL
 local ESC_MAP = Constant.ESC_MAP
 
-local function kind_of(obj)
+local function kind_of(obj, empty_table_as_array)
     if type(obj) ~= "table" then return type(obj) end
     if obj == NULL then return "nil" end
 
@@ -14,7 +14,7 @@ local function kind_of(obj)
         if obj[i] ~= nil then i = i + 1 else return "table" end
     end
 
-    if i == 1 then
+    if i == 1 and not empty_table_as_array then
         return "table"
     else
         return "array"
@@ -49,6 +49,7 @@ local Serializer = {
     print_address = false,
     sort_table_keys = false,
     escape_string_values = true,
+    empty_table_as_array = false,
     max_depth = 100000
 }
 
@@ -60,6 +61,7 @@ setmetatable(Serializer, {
             print_address = opts.print_address,
             sort_table_keys = opts.sort_table_keys,
             escape_string_values = opts.escape_string_values,
+            empty_table_as_array = opts.empty_table_as_array,
             stream = opts.stream
         }
 
@@ -150,7 +152,7 @@ end
 
 function Serializer:json(obj, replacer, indent, space)
     local stream = self.stream
-    local kind = kind_of(obj)
+    local kind = kind_of(obj, self.empty_table_as_array)
 
     self.depth = self.depth + 1
     if self.depth > self.max_depth then error("Reach max depth: " .. tostring(self.max_depth)) end


### PR DESCRIPTION
If a table is empty then it will result in `{}`, which an an empty object. This adds an `empty_table_as_array` option so that the user can specify if they want empty tables to result in `[]`.